### PR TITLE
feat(tui): preserve task.config.json order when displaying tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures-util",
+ "indexmap",
  "libc",
  "nanoid",
  "sea-orm",

--- a/apps/tui/src/lib/task-structure.ts
+++ b/apps/tui/src/lib/task-structure.ts
@@ -20,9 +20,7 @@ export function flattenTaskRows(taskTree: TaskTreeNode[]): TaskRow[] {
 
 export function buildTaskTree(tasks: Record<string, Task>): TaskTreeNode[] {
 	const buildNode = (taskKey: string): TaskTreeNode => {
-		const childKeys = getDirectChildTaskKeys(tasks, taskKey).sort((a, b) =>
-			a.localeCompare(b)
-		);
+		const childKeys = getDirectChildTaskKeys(tasks, taskKey);
 		return {
 			row: createTaskRow(taskKey),
 			children: childKeys.map((childKey) => buildNode(childKey)),
@@ -31,7 +29,6 @@ export function buildTaskTree(tasks: Record<string, Task>): TaskTreeNode[] {
 
 	return Object.keys(tasks)
 		.filter((taskKey) => !taskKey.includes(":"))
-		.sort((a, b) => a.localeCompare(b))
 		.map((taskKey) => buildNode(taskKey));
 }
 

--- a/crates/bizi-server/Cargo.toml
+++ b/crates/bizi-server/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 axum = { version = "0.7", features = ["ws"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "fs", "process", "sync", "signal"] }
-utoipa = { version = "4" }
+utoipa = { version = "4", features = ["indexmap"] }
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -27,4 +27,5 @@ nanoid = "0.4.0"
 chrono = "0.4.43"
 libc = "0.2"
 futures-util = "0.3"
+indexmap = { version = "2", features = ["serde"] }
 

--- a/crates/bizi-server/src/api/tasks.rs
+++ b/crates/bizi-server/src/api/tasks.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, HashSet};
+
+use indexmap::IndexMap;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::OnceLock;
@@ -60,7 +62,7 @@ pub struct ListTaskRunsRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ListTasksResponseBody {
     /// The list of tasks that are defined in the task.config.json file
-    pub tasks: HashMap<String, Task>,
+    pub tasks: IndexMap<String, Task>,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]

--- a/crates/bizi-server/src/config/mod.rs
+++ b/crates/bizi-server/src/config/mod.rs
@@ -1,5 +1,6 @@
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, io::ErrorKind, path::Path};
+use std::{io::ErrorKind, path::Path};
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -16,13 +17,13 @@ pub struct Task {
     /// Whether the task is optional. If true, the task will only run if started manually.
     pub optional: Option<bool>,
     /// Subtasks of this task. Keys must be unique task names.
-    pub tasks: Option<HashMap<String, Task>>,
-    pub depends_on_tasks: Option<HashMap<String, Task>>,
+    pub tasks: Option<IndexMap<String, Task>>,
+    pub depends_on_tasks: Option<IndexMap<String, Task>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-    pub tasks: HashMap<String, Task>,
+    pub tasks: IndexMap<String, Task>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -56,7 +57,7 @@ impl Config {
         };
 
         if let Some(depends_on) = &task.depends_on {
-            let mut depends_on_tasks = HashMap::new();
+            let mut depends_on_tasks = IndexMap::new();
             for key in depends_on.iter() {
                 let depends_on_task = get_task(&self.tasks, key.clone());
                 if let Some(depends_on_task) = depends_on_task {
@@ -69,13 +70,13 @@ impl Config {
         Some(task)
     }
 
-    pub fn get_all_tasks(&self) -> HashMap<String, Task> {
+    pub fn get_all_tasks(&self) -> IndexMap<String, Task> {
         get_all_tasks(&self.tasks, None)
     }
 }
 
 /// Handles getting nested tasks like `dev:packages` or `dev:server`.
-fn get_task(tasks: &HashMap<String, Task>, task_key: String) -> Option<&Task> {
+fn get_task(tasks: &IndexMap<String, Task>, task_key: String) -> Option<&Task> {
     let task_key_segments = task_key.split(":").collect::<Vec<&str>>();
     if task_key_segments.len() == 0 {
         return None;
@@ -93,9 +94,12 @@ fn get_task(tasks: &HashMap<String, Task>, task_key: String) -> Option<&Task> {
     Some(task)
 }
 
-fn get_all_tasks(tasks: &HashMap<String, Task>, base_key: Option<String>) -> HashMap<String, Task> {
+fn get_all_tasks(
+    tasks: &IndexMap<String, Task>,
+    base_key: Option<String>,
+) -> IndexMap<String, Task> {
     let base = base_key.map(|k| k + ":").unwrap_or("".to_string());
-    let mut task_keys: HashMap<String, Task> = HashMap::new();
+    let mut task_keys: IndexMap<String, Task> = IndexMap::new();
     for (key, task) in tasks.iter() {
         task_keys.insert(format!("{}{}", &base, key), task.clone());
         if let Some(tasks) = &task.tasks {


### PR DESCRIPTION
Switch bizi-server task maps from HashMap to IndexMap so JSON
insertion order is preserved through parsing and serialization,
and drop the alphabetical sort in the TUI's buildTaskTree so tasks
render in the order they are defined in task.config.json.

https://claude.ai/code/session_013S7iHDmKrJUUskuyY7oaHL